### PR TITLE
Making Credentials & ProxyInfo Serializable

### DIFF
--- a/src/main/java/com/synopsys/integration/rest/credentials/Credentials.java
+++ b/src/main/java/com/synopsys/integration/rest/credentials/Credentials.java
@@ -22,6 +22,8 @@
  */
 package com.synopsys.integration.rest.credentials;
 
+import java.io.Serializable;
+
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -29,7 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.synopsys.integration.builder.Buildable;
 import com.synopsys.integration.util.Stringable;
 
-public class Credentials extends Stringable implements Buildable {
+public class Credentials extends Stringable implements Buildable, Serializable {
     public static final Credentials NO_CREDENTIALS = new Credentials(null, null);
 
     public static CredentialsBuilder newBuilder() {

--- a/src/main/java/com/synopsys/integration/rest/proxy/ProxyInfo.java
+++ b/src/main/java/com/synopsys/integration/rest/proxy/ProxyInfo.java
@@ -22,6 +22,7 @@
  */
 package com.synopsys.integration.rest.proxy;
 
+import java.io.Serializable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -33,7 +34,7 @@ import com.synopsys.integration.builder.Buildable;
 import com.synopsys.integration.rest.credentials.Credentials;
 import com.synopsys.integration.util.Stringable;
 
-public class ProxyInfo extends Stringable implements Buildable {
+public class ProxyInfo extends Stringable implements Buildable, Serializable {
     public final static ProxyInfo NO_PROXY_INFO = new ProxyInfo();
 
     public static ProxyInfoBuilder newBuilder() {


### PR DESCRIPTION
This is in addition to a fix for the jenkins plugin so that the Callable
can store the ProxyInfo before being executed on a remote agent.