### PR TITLE
improved error reporting in IntHttpClient.executeGetRequestIfModifiedSince()

### DIFF
--- a/src/main/java/com/synopsys/integration/rest/client/IntHttpClient.java
+++ b/src/main/java/com/synopsys/integration/rest/client/IntHttpClient.java
@@ -210,6 +210,9 @@ public class IntHttpClient {
 
         long lastModifiedOnServer = 0L;
         try (Response headResponse = execute(createHttpUriRequest(headRequest))) {
+            if (headResponse.isStatusCodeError()) {
+                throw new IntegrationException(String.format("GET request to %s returned HTTP status code %d", getRequest.getUrl().string(), headResponse.getStatusCode()));
+            }
             lastModifiedOnServer = headResponse.getLastModified();
             logger.debug(String.format("Last modified on server: %d", lastModifiedOnServer));
         } catch (IntegrationException e) {

--- a/src/test/groovy/com/synopsys/integration/rest/client/IntHttpClientTest.java
+++ b/src/test/groovy/com/synopsys/integration/rest/client/IntHttpClientTest.java
@@ -1,0 +1,50 @@
+package com.synopsys.integration.rest.client;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.log.BufferedIntLogger;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.rest.proxy.ProxyInfo;
+import com.synopsys.integration.rest.request.Request;
+
+import com.synopsys.integration.rest.HttpUrl;
+
+public class IntHttpClientTest {
+
+    @Test
+    public void testExecuteGetRequestIfModifiedSinceGets404() throws IOException, IntegrationException {
+        IntLogger logger = new BufferedIntLogger();
+        int timeoutInSeconds = 30;
+        boolean alwaysTrustServerCertificate = true;
+        ProxyInfo proxyInfo = ProxyInfo.NO_PROXY_INFO;
+        CredentialsProvider credentialsProvider = null;
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create();
+        RequestConfig.Builder defaultRequestConfigBuilder = RequestConfig.custom();
+        Map<String, String> commonRequestHeaders = new HashMap<>(0);
+
+        IntHttpClient client = new IntHttpClient(logger, timeoutInSeconds, alwaysTrustServerCertificate, proxyInfo,
+            credentialsProvider, clientBuilder, defaultRequestConfigBuilder, commonRequestHeaders);
+
+        HttpUrl url = new HttpUrl("https://google.com/download/thisdoesntexist.zip");
+        Request getRequest = new Request.Builder()
+                                 .url(url)
+                                 .build();
+        long timeToCheck = 0L;
+        try {
+            client.executeGetRequestIfModifiedSince(getRequest, timeToCheck);
+            fail("Expected an exception in response to an HTTP 404");
+        } catch (IntegrationException e) {
+            System.out.printf("Got the expected exception type. The exception message is:\n\t%s\n", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This is a simplistic fix for improving error reporting in IntHttpClient.executeGetRequestIfModifiedSince()  (IDETECT-2139). My main intention at this point is to show the change in behavior I'd like to see. We can discuss how it should best be done. (I don't think the test is worth keeping, at least not in it's current form; it's there to demonstrate the desired behavior.)

The problem with the current behavior (as it plays out in Detect): When the server returns a 404 when the file-to-be-downloaded doesn't exist, the current code treats that as "success".
