### PR TITLE
IALERT-3427 Use createSystemDefault

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins { id 'groovy' }
 project.ext.moduleName = 'com.synopsys.integration.integration-rest'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '10.3.9-SNAPSHOT'
+version = '10.4.0-SNAPSHOT'
 description = 'A library wrapping http communication for integrations.'
 
 apply plugin: 'com.synopsys.integration.library'

--- a/src/main/java/com/synopsys/integration/rest/client/IntHttpClient.java
+++ b/src/main/java/com/synopsys/integration/rest/client/IntHttpClient.java
@@ -54,7 +54,6 @@ import com.google.gson.Gson;
 import com.jayway.jsonpath.JsonPath;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.IntLogger;
-import com.synopsys.integration.log.LogLevel;
 import com.synopsys.integration.rest.HttpMethod;
 import com.synopsys.integration.rest.body.BodyContent;
 import com.synopsys.integration.rest.body.BodyContentConverter;
@@ -71,7 +70,7 @@ import com.synopsys.integration.util.MaskedStringFieldToStringBuilder;
  * A basic, extendable http client.
  */
 public class IntHttpClient {
-    public static final Supplier<SSLContext> SSL_CONTEXT_SUPPLIER = SSLContexts::createDefault;
+    public static final Supplier<SSLContext> SSL_CONTEXT_SUPPLIER = SSLContexts::createSystemDefault;
     public static final String ERROR_MSG_PROXY_INFO_NULL = "A IntHttpClient's proxy information cannot be null.";
     public static final int DEFAULT_TIMEOUT = 120;
 


### PR DESCRIPTION
- Use SSLContext**s**.createSystemDefault instead of createDefault to:

1. Respect system properties. The keystore within SSLContext was not being built as defined by system properties when starting spring. This was discovered in https://jira-sig.internal.synopsys.com/browse/IALERT-3427.

2. Allow the usage of SSLContext.setDefault which enables custom SSLContext per application. SSLContexts.createDefault did not use the context set by SSLContext.setDefault while SSLContexts.createSystemDefault does. If there is a wish to use original implementation, setting it back via `SSLContext.setDefault(SSLContexts.createDefault())` will suffice prior to initializing the HTTP client (or during startup).

Note: SSLContexts vs SSLContext