### PR TITLE
Revert createSystem back to createDefault

### DIFF
--- a/src/main/java/com/synopsys/integration/rest/client/IntHttpClient.java
+++ b/src/main/java/com/synopsys/integration/rest/client/IntHttpClient.java
@@ -70,7 +70,7 @@ import com.synopsys.integration.util.MaskedStringFieldToStringBuilder;
  * A basic, extendable http client.
  */
 public class IntHttpClient {
-    public static final Supplier<SSLContext> SSL_CONTEXT_SUPPLIER = SSLContexts::createSystemDefault;
+    public static final Supplier<SSLContext> SSL_CONTEXT_SUPPLIER = SSLContexts::createDefault;
     public static final String ERROR_MSG_PROXY_INFO_NULL = "A IntHttpClient's proxy information cannot be null.";
     public static final int DEFAULT_TIMEOUT = 120;
 


### PR DESCRIPTION
createDefault creates and inits a new SSLContext which in some cases allows us to reload stores. There is a workaround to setDefault to a new context everytime we want to reload but we felt inclined to rollback the change instead.