### PR TITLE
IALERT-3579 - Enhance library to add constructor for SSLContext

### DIFF
--- a/src/main/java/com/synopsys/integration/rest/client/AuthenticatingIntHttpClient.java
+++ b/src/main/java/com/synopsys/integration/rest/client/AuthenticatingIntHttpClient.java
@@ -24,9 +24,15 @@ import com.synopsys.integration.rest.RestConstants;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.response.Response;
 
+import javax.net.ssl.SSLContext;
+
 public abstract class AuthenticatingIntHttpClient extends IntHttpClient {
     public AuthenticatingIntHttpClient(IntLogger logger, Gson gson, int timeoutInSeconds, boolean alwaysTrustServerCertificate, ProxyInfo proxyInfo) {
         super(logger, gson, timeoutInSeconds, alwaysTrustServerCertificate, proxyInfo);
+    }
+
+    public AuthenticatingIntHttpClient(IntLogger logger, Gson gson, int timeoutInSeconds, ProxyInfo proxyInfo, SSLContext sslContext) {
+        super(logger, gson, timeoutInSeconds, proxyInfo, sslContext);
     }
 
     public AuthenticatingIntHttpClient(IntLogger logger, Gson gson, int timeoutInSeconds, boolean alwaysTrustServerCertificate, ProxyInfo proxyInfo, CredentialsProvider credentialsProvider, HttpClientBuilder clientBuilder,

--- a/src/main/java/com/synopsys/integration/rest/client/BasicAuthHttpClient.java
+++ b/src/main/java/com/synopsys/integration/rest/client/BasicAuthHttpClient.java
@@ -22,6 +22,8 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.response.Response;
 import com.synopsys.integration.rest.support.AuthenticationSupport;
 
+import javax.net.ssl.SSLContext;
+
 public class BasicAuthHttpClient extends AuthenticatingIntHttpClient {
     private static final String AUTHORIZATION_TYPE = "Basic";
 
@@ -31,8 +33,16 @@ public class BasicAuthHttpClient extends AuthenticatingIntHttpClient {
 
     public BasicAuthHttpClient(IntLogger logger, Gson gson, int timeout, boolean alwaysTrustServerCertificate, ProxyInfo proxyInfo, AuthenticationSupport authenticationSupport, String username, String password) {
         super(logger, gson, timeout, alwaysTrustServerCertificate, proxyInfo);
-        this.authenticationSupport = authenticationSupport;
 
+        this.authenticationSupport = authenticationSupport;
+        this.username = username;
+        this.password = password;
+    }
+
+    public BasicAuthHttpClient(IntLogger logger, Gson gson, int timeout, ProxyInfo proxyInfo, SSLContext sslContext, AuthenticationSupport authenticationSupport, String username, String password) {
+        super(logger, gson, timeout, proxyInfo, sslContext);
+
+        this.authenticationSupport = authenticationSupport;
         this.username = username;
         this.password = password;
     }


### PR DESCRIPTION
IntHttpClient already exposes a constructor which accepts an SSLContext. Extend this to classes which extend IntHttpClient. This logic will be consumed in [int-jira-common](https://github.com/blackducksoftware/int-jira-common)