### PR TITLE
Fix: Ensure there is only one Authorization header.

### DIFF
--- a/src/main/java/com/blackduck/integration/rest/support/AuthenticationSupport.java
+++ b/src/main/java/com/blackduck/integration/rest/support/AuthenticationSupport.java
@@ -128,7 +128,7 @@ public class AuthenticationSupport {
 
     public void addAuthenticationHeader(AuthenticatingIntHttpClient authenticatingIntHttpClient, HttpUriRequest request, String headerName, String headerValue) {
         authenticatingIntHttpClient.addCommonRequestHeader(headerName, headerValue);
-        request.addHeader(headerName, headerValue);
+        request.setHeader(headerName, headerValue);
     }
 
 }

--- a/src/test/java/com/blackduck/integration/rest/support/AuthenticationSupportTest.java
+++ b/src/test/java/com/blackduck/integration/rest/support/AuthenticationSupportTest.java
@@ -17,9 +17,9 @@ import com.blackduck.integration.rest.HttpMethod;
 import com.blackduck.integration.rest.HttpUrl;
 import com.blackduck.integration.rest.client.AuthenticatingIntHttpClient;
 
-public class AuthenticationSupportTest {
+class AuthenticationSupportTest {
     @Test
-    public void testContentLengthSetWithoutEntity() throws IntegrationException, IOException {
+    void testContentLengthSetWithoutEntity() throws IntegrationException, IOException {
         CloseableHttpClient mockHttpClient = Mockito.mock(CloseableHttpClient.class);
         HttpClientBuilder mockHttpClientBuilder = Mockito.mock(HttpClientBuilder.class);
         Mockito.when(mockHttpClientBuilder.build()).thenReturn(mockHttpClient);
@@ -38,6 +38,28 @@ public class AuthenticationSupportTest {
 
         Assertions.assertTrue(requestCaptor.getValue().containsHeader(HttpHeaders.CONTENT_LENGTH));
         Assertions.assertEquals("0", requestCaptor.getValue().getFirstHeader(HttpHeaders.CONTENT_LENGTH).getValue());
+    }
+
+
+
+    @Test
+    void testReplaceAuthorizationHeader() {
+        CloseableHttpClient mockHttpClient = Mockito.mock(CloseableHttpClient.class);
+        HttpClientBuilder mockHttpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+        Mockito.when(mockHttpClientBuilder.build()).thenReturn(mockHttpClient);
+
+        AuthenticatingIntHttpClient mockClient = Mockito.mock(AuthenticatingIntHttpClient.class);
+        Mockito.when(mockClient.getClientBuilder()).thenReturn(mockHttpClientBuilder);
+
+        AuthenticationSupport authenticationSupport = new AuthenticationSupport();
+        RequestBuilder requestBuilder = RequestBuilder.create(HttpMethod.POST.name());
+        HttpUriRequest request = requestBuilder.build();
+
+        authenticationSupport.addAuthenticationHeader(mockClient, request, AuthenticationSupport.AUTHORIZATION_HEADER, "Original Authorization Value");
+        authenticationSupport.addAuthenticationHeader(mockClient, request, AuthenticationSupport.AUTHORIZATION_HEADER, "Updated Authorization Value");
+        Assertions.assertTrue(request.containsHeader(HttpHeaders.AUTHORIZATION));
+        Assertions.assertEquals(1, request.getHeaders(HttpHeaders.AUTHORIZATION).length);
+        Assertions.assertEquals("Updated Authorization Value", request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue());
     }
 
 }


### PR DESCRIPTION
When `addAuthenticationHeader` is called in `AuthenticationSupport` to handle a retry of a request it would all the `addHeader` method.  The code would add an Authorization header.  If there was an Authorization header already present in the request the add method would not replace the existing Authorization header.  It would add a second Authorization header.  A request with two Authorization header can result in a 400 bad request.

Change the `addHeader` method to `setHeader` in order to add or replace an existing Authorization header with the new value on the request that will be retried.  This provides the same functionality that the following line of code provides to the HTTP client for future requests: `authenticatingIntHttpClient.addCommonRequestHeader(headerName, headerValue);`