### PR TITLE
IALERT-3828 - Update timestamp to comply with Java time defaults

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins { id 'groovy' }
 project.ext.moduleName = 'com.blackduck.integration.integration-rest'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '11.0.3-SNAPSHOT'
+version = '11.1.0-SNAPSHOT'
 description = 'A library wrapping http communication for integrations.'
 
 apply plugin: 'com.blackduck.integration.library'

--- a/src/main/java/com/blackduck/integration/rest/RestConstants.java
+++ b/src/main/java/com/blackduck/integration/rest/RestConstants.java
@@ -14,7 +14,7 @@ import java.util.Date;
 import java.util.TimeZone;
 
 public class RestConstants {
-    public static final String JSON_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+    public static final String JSON_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
     /* 2XX: generally "OK" */
     public static final int OK_200 = HttpURLConnection.HTTP_OK;


### PR DESCRIPTION
BD SCA moved away from Joda-Time in favor of Java built in. Our current format is not supported by default, and causes a failure when using endpoints that use it. This change updates the date format to a supported one.

Testing done including releasing snapshot libraries locally, and configuring Alert to use these snapshot libraries. With these snapshot libraries containing the fix within this PR, Alert does not get a failure when hitting endpoints with date/time.