### PR TITLE
IALERT-3828 - Revert change to date format

### DIFF
--- a/src/main/java/com/blackduck/integration/rest/RestConstants.java
+++ b/src/main/java/com/blackduck/integration/rest/RestConstants.java
@@ -14,7 +14,7 @@ import java.util.Date;
 import java.util.TimeZone;
 
 public class RestConstants {
-    public static final String JSON_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    public static final String JSON_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
 
     /* 2XX: generally "OK" */
     public static final int OK_200 = HttpURLConnection.HTTP_OK;


### PR DESCRIPTION
Changing the date format does not fix the issue, so to avoid and usage of this fix, reverting the change.